### PR TITLE
Rename Object to DataObject

### DIFF
--- a/Model/Object/ClassDefinition/Data/ObjectBridge.php
+++ b/Model/Object/ClassDefinition/Data/ObjectBridge.php
@@ -6,7 +6,7 @@ namespace ObjectBridgeBundle\Model\Object\ClassDefinition\Data;
 use PDO;
 use Pimcore\Logger;
 use Pimcore\Model;
-use Pimcore\Model\Object;
+use Pimcore\Model\DataObject;
 use Pimcore\Model\Element;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition;


### PR DESCRIPTION
Renamed Object to DataObject because it is a reserved word in php 7.2