### PR TITLE
Bugfix for dropdown that didn't show up, now correct namespace

### DIFF
--- a/Model/DataObject/ClassDefinition/Data/ObjectBridge.php
+++ b/Model/DataObject/ClassDefinition/Data/ObjectBridge.php
@@ -980,8 +980,9 @@ class ObjectBridge extends ClassDefinition\Data\ObjectsMetadata
         if (method_exists($fd, 'getDefaultValue') && strlen(strval($fd->getDefaultValue())) > 0) {
             $this->$fieldName[ $field ]['default'] =  $fd->getDefaultValue();
         }
+        
         // Dropdowns have options
-        if ($fd instanceof Object\ClassDefinition\Data\Select) {
+        if ($fd instanceof ClassDefinition\Data\Select) {
             $this->$fieldName[ $field ]['options'] = $fd->getOptions();
         }
     }


### PR DESCRIPTION
The dropdown was not showing up anymore after updates for php 7.2 compatibly