### PR TITLE
[BUGFIX] Select value displayed instead of label

### DIFF
--- a/Resources/public/js/pimcore/objects/tags/objectBridge.js
+++ b/Resources/public/js/pimcore/objects/tags/objectBridge.js
@@ -139,11 +139,12 @@ pimcore.object.tags.objectBridge = Class.create(pimcore.object.tags.objects, {
             return checkBoxColumn;
         }
 
-        else if (layout.fieldtype === "select" && !readOnly) {
+        else if (layout.fieldtype === "select") {
             renderer = this.renderDisplayField;
             editor = Ext.create('Ext.form.ComboBox', {
                 allowBlank: !layout.mandatory,
                 typeAhead: true,
+                readOnly: readOnly,
                 forceSelection: true,
                 mode: 'local',
                 queryMode: 'local',


### PR DESCRIPTION
When the field is not editable and therefore rendered in 'show' layout, the select is not rendered and the plain value is displayed instead of the label. This is an issue especially when non-meaningful values are used, like integers.
Fixed by removing the 'not readonly' check, so the select is always rendered, and applying the check to the select configuration instead.