### PR TITLE
changed joinInner for getBridgeIdBySourceAndOwner to filter by type='object'

### DIFF
--- a/Model/DataObject/ClassDefinition/Data/ObjectBridge.php
+++ b/Model/DataObject/ClassDefinition/Data/ObjectBridge.php
@@ -544,7 +544,7 @@ class ObjectBridge extends ClassDefinition\Data\Relations\AbstractRelations impl
         $db = Db::get();
         $select = $db->select()
             ->from(['dor' => 'object_relations_' . $object::classId()], [])
-            ->joinInner(['dp_objects' => 'object_' . $bridgeClass::classId()], 'dor.dest_id = dp_objects.oo_id', ['oo_id'])
+            ->joinInner(['dp_objects' => 'object_' . $bridgeClass::classId()], 'dor.dest_id = dp_objects.oo_id AND dor.type = "object"', ['oo_id'])
             ->where('dor.src_id = ?', $object->getId())
             ->where('dp_objects.' . $this->bridgeField . '__id = ?', $sourceId);
 


### PR DESCRIPTION
changed joinInner for getBridgeIdBySourceAndOwner to filter by type='object'.

Change was made so that assets and documents do not show up on the search.